### PR TITLE
Fix "⚙️⚙️⚙️" being displayed sometimes

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "shell-version" : [
         "3.36",
 	    "3.38",
-        "40"
+        "40",
+        "41"
     ],
     "url" : "https://github.com/esenliyim/sp-tray",
     "uuid" : "sp-tray@sp-tray.esenliyim.github.com",

--- a/panelButton.js
+++ b/panelButton.js
@@ -132,6 +132,10 @@ var SpTrayButton = GObject.registerClass(
                         button.set_text(this.settings.get_string("paused"));
                     }
                 } else {
+                    if (!metadata['xesam:title'] || !metadata['xesam:album'] ||!metadata['xesam:albumArtist']) {
+                        this.visible = false;
+                        return true;
+                    }
                     if (!this.visible) {
                         this.visible = true;
                     }


### PR DESCRIPTION
this checks to make sure the data looks like spotify data before trying to use it, fixing playback w/ youtube in chromium causing ⚙️⚙️⚙️ (the loading string) to appear erroneously.