### PR TITLE
chore: implement code formatting

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+    singleQuote: false,
+    tabWidth: 4,
+    trailingComma: "none",
+    overrides: [
+        {
+            files: ["*.md", "*.MD"],
+            options: {
+                tabWidth: 2
+            }
+        }
+    ]
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,21 @@ Here be the notable changes to the extension's function.
 ## Version 14 | 2022-05-12
 
 Added:
+
 - Support for [ncspot](https://github.com/hrkfdn/ncspot)
 - Can now keep displaying track info even when playback is paused.
 
 Changed:
+
 - Now respects the `{artist}` placeholder for podcasts, even though currently Spotify returns nothing for that field.
 
 ## Version 13 | 2022-05-01
 
-Added:   
+Added:
+
 - A changelog, finally.
 - Support for Spotify version 1.1.84.
 
-Changed: 
+Changed:
+
 - Spotify logo now hidden by default.

--- a/README.MD
+++ b/README.MD
@@ -1,9 +1,8 @@
-
 # sp-tray
 
-sp-tray is a very simple GNOME Shell extension that displays current track information in the system tray using Spotify's dbus interface without using the web API. There are no playback controls and/or album art display, and there never will be. This is intended to be nothing more than a simple label for Spotify only. 
+sp-tray is a very simple GNOME Shell extension that displays current track information in the system tray using Spotify's dbus interface without using the web API. There are no playback controls and/or album art display, and there never will be. This is intended to be nothing more than a simple label for Spotify only.
 
-Screenshot: 
+Screenshot:
 ![tray](https://raw.githubusercontent.com/esenliyim/sp-tray/multi-gtk/example.png)
 
 ## Features
@@ -16,12 +15,11 @@ Screenshot:
 
 - Works on Wayland as well as X
 
-## Installation 
+## Installation
 
 Preferably, you should:
 
 [<img src="https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true" alt="Get it on GNOME Extensions" height="100" align="middle">][extlink]
-
 
 Alternatively, you could:
 
@@ -29,11 +27,11 @@ Alternatively, you could:
 
 2. Run the install script with `./<path_to_dir>/install.sh`. By default the files are copied into a new directory under `~/.local/share/gnome-shell/extensions/`.
 
-2. Restart gnome-shell (xorg) and activate the extension via gnome-tweaks. Gnome-shell cannot be restarted under Wayland, so you may have to log out and back in.
+3. Restart gnome-shell (xorg) and activate the extension via gnome-tweaks. Gnome-shell cannot be restarted under Wayland, so you may have to log out and back in.
 
-## Dependencies 
+## Dependencies
 
-* `libgtop` and gnome-tweaks as usual to load/install GNOME shell extensions.
+- `libgtop` and gnome-tweaks as usual to load/install GNOME shell extensions.
 
 ## Notes
 
@@ -41,7 +39,7 @@ I haven't tested it with any shell version older than 3.36 because I can't be bo
 
 English, German and Turkish translations are provided by me. If you'd like to contribute translations, please contact me.
 
-## License 
+## License
 
 GPLv2+
 

--- a/extension.js
+++ b/extension.js
@@ -13,7 +13,7 @@
 //     You should have received a copy of the GNU General Public License
 // along with this program.If not, see < http://www.gnu.org/licenses/>.
 
-'use strict';
+"use strict";
 
 const Main = imports.ui.main;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
@@ -33,8 +33,13 @@ class SpTrayExtension {
     }
 
     _addToTray() {
-        let pos = this.settings.get_int('position');
-        Main.panel.addToStatusArea('SpTray', this.extensionButton, pos == 2 ? 0 : -1, this._getPosition(pos));
+        let pos = this.settings.get_int("position");
+        Main.panel.addToStatusArea(
+            "SpTray",
+            this.extensionButton,
+            pos == 2 ? 0 : -1,
+            this._getPosition(pos)
+        );
     }
 
     disable() {
@@ -44,11 +49,11 @@ class SpTrayExtension {
     }
 
     _getPosition(pos) {
-        let positions = ['left' , 'center', 'right'];
+        let positions = ["left", "center", "right"];
         return positions[pos];
     }
 }
 
-function init () {
+function init() {
     return new SpTrayExtension();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,15 @@
 {
-    "description" : "Adds a button to the panel that shows currently playing track on Spotify",
-    "name" : "spotify-tray",
-    "shell-version" : [
+    "description": "Adds a button to the panel that shows currently playing track on Spotify",
+    "name": "spotify-tray",
+    "shell-version": [
         "3.36",
-	    "3.38",
+        "3.38",
         "40",
         "41",
         "42"
     ],
-    "url" : "https://github.com/esenliyim/sp-tray",
-    "uuid" : "sp-tray@sp-tray.esenliyim.github.com",
-    "version" : 13,
-    "settings-schema" : "org.gnome.shell.extensions.sp-tray"
+    "url": "https://github.com/esenliyim/sp-tray",
+    "uuid": "sp-tray@sp-tray.esenliyim.github.com",
+    "version": 13,
+    "settings-schema": "org.gnome.shell.extensions.sp-tray"
 }

--- a/panelButton.js
+++ b/panelButton.js
@@ -16,7 +16,7 @@
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const Main = imports.ui.main;
-const {St, Clutter, GObject, GLib, Gio} = imports.gi;
+const { St, Clutter, GObject, GLib, Gio } = imports.gi;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -35,24 +35,23 @@ const supportedClients = [
     {
         name: "spotify version <1.84",
         pattern: "spotify:",
-        idExtractor: (trackid) => (trackid.split(":")[2])
+        idExtractor: (trackid) => trackid.split(":")[2]
     },
     {
         name: "spotify version >1.84",
         pattern: "/com/spotify",
-        idExtractor: (trackid) => (trackid.split("/")[3])
+        idExtractor: (trackid) => trackid.split("/")[3]
     },
     {
         name: "ncspot",
         pattern: "/org/ncspot",
-        idExtractor: (trackid) => (trackid.split("/")[4])
-    },
-]
+        idExtractor: (trackid) => trackid.split("/")[4]
+    }
+];
 
 var SpTrayButton = GObject.registerClass(
-    {GTypeName: "SpTrayButton"},
+    { GTypeName: "SpTrayButton" },
     class SpTrayButton extends PanelMenu.Button {
-
         _init() {
             super._init(null, Me.metadata.name);
 
@@ -65,7 +64,6 @@ var SpTrayButton = GObject.registerClass(
             this._initUi();
 
             this.updateText();
-
         }
 
         _initSettings() {
@@ -73,8 +71,18 @@ var SpTrayButton = GObject.registerClass(
 
             // connect relevant settings to the button so that it can be instantly updated when they're changed
             // store the connected signals in an array for easy disconnection later on
-            this._settingSignals.push(this.settings.connect(`changed::paused`, this.updateText.bind(this)));
-            this._settingSignals.push(this.settings.connect(`changed::off`, this.updateText.bind(this)));
+            this._settingSignals.push(
+                this.settings.connect(
+                    `changed::paused`,
+                    this.updateText.bind(this)
+                )
+            );
+            this._settingSignals.push(
+                this.settings.connect(
+                    `changed::off`,
+                    this.updateText.bind(this)
+                )
+            );
             this._settingSignals.push(
                 this.settings.connect(
                     `changed::hidden-when-inactive`,
@@ -132,18 +140,26 @@ var SpTrayButton = GObject.registerClass(
         }
 
         _initUi() {
-            const box = new St.BoxLayout({style_class: "panel-status-menu-box"});
+            const box = new St.BoxLayout({
+                style_class: "panel-status-menu-box"
+            });
             this.ui.set("box", box);
 
-            this.ui.set("label", new St.Label({
-                text: this.settings.get_string("starting"),
-                y_align: Clutter.ActorAlign.CENTER,
-            }));
-            this.ui.set("icon", new St.Icon({
-                icon_name: "spotify",
-                style_class: "system-status-icon",
-            }))
-            this._handleLogoDisplay()
+            this.ui.set(
+                "label",
+                new St.Label({
+                    text: this.settings.get_string("starting"),
+                    y_align: Clutter.ActorAlign.CENTER
+                })
+            );
+            this.ui.set(
+                "icon",
+                new St.Icon({
+                    icon_name: "spotify",
+                    style_class: "system-status-icon"
+                })
+            );
+            this._handleLogoDisplay();
 
             // listen to spotify status changes to update the tray display immediately. no busy waiting
             this._settingSignals.push(
@@ -154,37 +170,44 @@ var SpTrayButton = GObject.registerClass(
             );
 
             // TODO signals array?
-            this._signals.push(this._pressEvent = this.connect(
-                "button-press-event",
-                this.showSpotify.bind(this)
-            ));
+            this._signals.push(
+                (this._pressEvent = this.connect(
+                    "button-press-event",
+                    this.showSpotify.bind(this)
+                ))
+            );
 
             this.add_child(box);
         }
 
         _initDbus() {
-            let spotifyProxyWrapper = Gio.DBusProxy.makeProxyWrapper(spotifyDbus);
-            this.spotifyProxy = spotifyProxyWrapper(Gio.DBus.session, dest, path);
+            let spotifyProxyWrapper =
+                Gio.DBusProxy.makeProxyWrapper(spotifyDbus);
+            this.spotifyProxy = spotifyProxyWrapper(
+                Gio.DBus.session,
+                dest,
+                path
+            );
         }
 
         // if the spotify logo is to be shown, insert it where appropriate (sounded better in my head)
         _handleLogoDisplay() {
-            let box = this.ui.get("box")
+            let box = this.ui.get("box");
             switch (this.settings.get_int("logo-position")) {
                 case 0:
-                    box.remove_all_children()
-                    box.add_child(this.ui.get("label"))
-                    break
+                    box.remove_all_children();
+                    box.add_child(this.ui.get("label"));
+                    break;
                 case 1:
-                    box.remove_all_children()
-                    box.add_child(this.ui.get("icon"))
-                    box.add_child(this.ui.get("label"))
-                    break
+                    box.remove_all_children();
+                    box.add_child(this.ui.get("icon"));
+                    box.add_child(this.ui.get("label"));
+                    break;
                 case 2:
-                    box.remove_all_children()
-                    box.add_child(this.ui.get("label"))
-                    box.add_child(this.ui.get("icon"))
-                    break
+                    box.remove_all_children();
+                    box.add_child(this.ui.get("label"));
+                    box.add_child(this.ui.get("icon"));
+                    break;
             }
         }
 
@@ -195,11 +218,14 @@ var SpTrayButton = GObject.registerClass(
             let positions = [
                 Main.panel._leftBox,
                 Main.panel._centerBox,
-                Main.panel._rightBox,
+                Main.panel._rightBox
             ];
 
             let pos = this.settings.get_int("position");
-            positions[pos].insert_child_at_index(this.container, pos == 2 ? 0 : -1);
+            positions[pos].insert_child_at_index(
+                this.container,
+                pos == 2 ? 0 : -1
+            );
         }
 
         destroy() {
@@ -207,9 +233,7 @@ var SpTrayButton = GObject.registerClass(
             this._settingSignals.forEach((signal) =>
                 this.settings.disconnect(signal)
             );
-            this._signals.forEach((signal) =>
-                this.settings.disconnect(signal)
-            );
+            this._signals.forEach((signal) => this.settings.disconnect(signal));
             // destroy all ui elements
             this.ui.forEach((element) => element.destroy());
             super.destroy();
@@ -222,7 +246,10 @@ var SpTrayButton = GObject.registerClass(
 
             if (!status) {
                 // spotify is inactive
-                if (this.settings.get_boolean("hidden-when-inactive") && this.visible) {
+                if (
+                    this.settings.get_boolean("hidden-when-inactive") &&
+                    this.visible
+                ) {
                     if (this.visible) {
                         this.visible = false;
                     }
@@ -240,9 +267,10 @@ var SpTrayButton = GObject.registerClass(
                     this.visible = false;
                     return true;
                 }
-                let text = '';
+                let text = "";
                 if (status === "Paused") {
-                    let hidden = this.settings.get_boolean("hidden-when-paused");
+                    let hidden =
+                        this.settings.get_boolean("hidden-when-paused");
                     if (hidden) {
                         if (this.visible) {
                             this.visible = false;
@@ -254,7 +282,10 @@ var SpTrayButton = GObject.registerClass(
                         }
                         text = this.settings.get_string("paused");
                         if (text.includes("{metadata}")) {
-                            text = text.replace("{metadata}", this._makeTrackData(client, metadata))
+                            text = text.replace(
+                                "{metadata}",
+                                this._makeTrackData(client, metadata)
+                            );
                         }
                     }
                 } else {
@@ -263,7 +294,7 @@ var SpTrayButton = GObject.registerClass(
                     if (!this.visible) {
                         this.visible = true;
                     }
-                    text = this._makeTrackData(client, metadata)
+                    text = this._makeTrackData(client, metadata);
                 }
                 button.set_text(text);
             }
@@ -271,8 +302,9 @@ var SpTrayButton = GObject.registerClass(
         }
 
         _makeTrackData(client, metadata) {
-
-            const trackType = client.idExtractor(metadata["mpris:trackid"].get_string()[0])
+            const trackType = client.idExtractor(
+                metadata["mpris:trackid"].get_string()[0]
+            );
             let format = this._getFormat(trackType);
 
             if (!format) {
@@ -281,23 +313,22 @@ var SpTrayButton = GObject.registerClass(
                 return true;
             }
 
-            return this._generateText(format, metadata)
+            return this._generateText(format, metadata);
         }
 
         _getFormat(trackType) {
             switch (trackType) {
                 case "track":
                 case "local":
-                    return this.settings.get_string("display-format")
+                    return this.settings.get_string("display-format");
                 case "episode":
-                    return this.settings.get_string("podcast-format")
+                    return this.settings.get_string("podcast-format");
                 default:
                     return null;
             }
         }
 
         _generateText(format, metadata) {
-
             let maxTitleLength = this.settings.get_int("title-max-length");
             let maxArtistLength = this.settings.get_int("artist-max-length");
             let maxAlbumLength = this.settings.get_int("album-max-length");
@@ -323,7 +354,7 @@ var SpTrayButton = GObject.registerClass(
                 .replace("{artist}", artist)
                 .replace("{track}", title)
                 .replace("{album}", album)
-                .trim()
+                .trim();
         }
 
         // many thanks to mheine's implementation
@@ -340,7 +371,9 @@ var SpTrayButton = GObject.registerClass(
                 let wins = global.get_window_actors(); // get all open windows
                 for (let win of wins) {
                     if (typeof win.get_meta_window === "function") {
-                        if (win.get_meta_window().get_wm_class() === "Spotify") {
+                        if (
+                            win.get_meta_window().get_wm_class() === "Spotify"
+                        ) {
                             this._spotiWin = win.get_meta_window(); // mark the spotify window
                         } else if (win.get_meta_window().has_focus()) {
                             this._notSpotify = win.get_meta_window(); // mark the window that was active when the button was pressed
@@ -361,7 +394,9 @@ var SpTrayButton = GObject.registerClass(
                 return null;
             }
             const trackId = metadata["mpris:trackid"].get_string()[0];
-            const client = supportedClients.filter(client => (trackId.startsWith(client.pattern)));
+            const client = supportedClients.filter((client) =>
+                trackId.startsWith(client.pattern)
+            );
             return client.length > 0 ? client[0] : null;
         }
     }

--- a/prefs.js
+++ b/prefs.js
@@ -33,97 +33,159 @@ function init() {
 }
 
 function buildPrefsWidget() {
-
     let settings = ExtensionUtils.getSettings();
     let builder = new Gtk.Builder();
     // use Gtk.BuilderScope to attach signal handlers to buttons on gtk 4+
     if (_isGtk4) {
         // register a new scope class if it hasn't already been registered
         if (registeredClass.length == 0) {
-            let SpBuilderScope = GObject.registerClass({
-                Implements: [Gtk.BuilderScope],
-            }, class SpBuilderScope extends GObject.Object {
-
-                vfunc_create_closure(builder, handlerName, flags, connectObject) {
-                    if (flags & Gtk.BuilderClosureFlags.SWAPPED) {
-                        throw new Error('Unsupported template signal flag "swapped"');
+            let SpBuilderScope = GObject.registerClass(
+                {
+                    Implements: [Gtk.BuilderScope]
+                },
+                class SpBuilderScope extends GObject.Object {
+                    vfunc_create_closure(
+                        builder,
+                        handlerName,
+                        flags,
+                        connectObject
+                    ) {
+                        if (flags & Gtk.BuilderClosureFlags.SWAPPED) {
+                            throw new Error(
+                                'Unsupported template signal flag "swapped"'
+                            );
+                        }
+                        if (typeof this[handlerName] === "undefined") {
+                            throw new Error(`${handlerName} is undefined`);
+                        }
+                        return this[handlerName].bind(connectObject || this);
                     }
-                    if (typeof this[handlerName] === 'undefined') {
-                        throw new Error(`${handlerName} is undefined`);
+
+                    on_defaults_clicked(connectObject) {
+                        settings.reset("off");
+                        settings.reset("paused");
+                        settings.reset("display-format");
                     }
-                    return this[handlerName].bind(connectObject || this);
-                }
 
-                on_defaults_clicked(connectObject) {
-                    settings.reset("off");
-                    settings.reset("paused");
-                    settings.reset("display-format");
-                }
+                    on_resetNotRunning_clicked(connectObject) {
+                        settings.reset("off");
+                    }
 
-                on_resetNotRunning_clicked(connectObject) {
-                    settings.reset("off");
-                }
+                    on_resetPaused_clicked(connectObject) {
+                        settings.reset("paused");
+                    }
 
-                on_resetPaused_clicked(connectObject) {
-                    settings.reset("paused");
-                }
+                    on_resetPosition_clicked(connectObject) {
+                        settings.reset("position");
+                    }
 
-                on_resetPosition_clicked(connectObject) {
-                    settings.reset("position");
-                }
+                    on_resetFormat_clicked(connectObject) {
+                        settings.reset("display-format");
+                    }
 
-                on_resetFormat_clicked(connectObject) {
-                    settings.reset("display-format");
-                }
+                    on_resetTitleLength_clicked(connectObject) {
+                        settings.reset("title-max-length");
+                    }
 
-                on_resetTitleLength_clicked(connectObject) {
-                    settings.reset("title-max-length");
-                }
+                    on_resetArtistLength_clicked(connectObject) {
+                        settings.reset("artist-max-length");
+                    }
 
-                on_resetArtistLength_clicked(connectObject) {
-                    settings.reset("artist-max-length");
-                }
+                    on_resetAlbumLength_clicked(connectObject) {
+                        settings.reset("album-max-length");
+                    }
 
-                on_resetAlbumLength_clicked(connectObject) {
-                    settings.reset("album-max-length");
-                }
+                    on_resetPodcastFormat_clicked(connectObject) {
+                        settings.reset("podcast-format");
+                    }
 
-                on_resetPodcastFormat_clicked(connectObject) {
-                    settings.reset("podcast-format");
+                    on_resetLogo_clicked(connectObject) {
+                        settings.reset("logo-position");
+                    }
                 }
-
-                on_resetLogo_clicked(connectObject) {
-                    settings.reset("logo-position");
-                }
-            });
+            );
             registeredClass.push(SpBuilderScope);
         }
         builder.set_scope(new registeredClass[0]());
     }
-    builder.add_from_file(Me.dir.get_path() + '/prefs.xml');
-    let box = builder.get_object('prefs_widget');
+    builder.add_from_file(Me.dir.get_path() + "/prefs.xml");
+    let box = builder.get_object("prefs_widget");
 
     // bind switches and text fields to their respective settings
-    settings.bind('display-format', builder.get_object('field_format'), 'text', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('podcast-format', builder.get_object('podcast_format'), 'text', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('title-max-length', builder.get_object('title_length'), 'value', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('artist-max-length', builder.get_object('artist_length'), 'value', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('album-max-length', builder.get_object('album_length'), 'value', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('paused', builder.get_object('field_paused'), 'text', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('hidden-when-inactive', builder.get_object('field_hideInactive'), 'active', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('hidden-when-paused', builder.get_object('field_hidePaused'), 'active', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('off', builder.get_object('field_notRunning'), 'text', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('position', builder.get_object('box_position'), 'active', Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('logo-position', builder.get_object('logo_position'), 'active', Gio.SettingsBindFlags.DEFAULT);
+    settings.bind(
+        "display-format",
+        builder.get_object("field_format"),
+        "text",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "podcast-format",
+        builder.get_object("podcast_format"),
+        "text",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "title-max-length",
+        builder.get_object("title_length"),
+        "value",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "artist-max-length",
+        builder.get_object("artist_length"),
+        "value",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "album-max-length",
+        builder.get_object("album_length"),
+        "value",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "paused",
+        builder.get_object("field_paused"),
+        "text",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "hidden-when-inactive",
+        builder.get_object("field_hideInactive"),
+        "active",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "hidden-when-paused",
+        builder.get_object("field_hidePaused"),
+        "active",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "off",
+        builder.get_object("field_notRunning"),
+        "text",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "position",
+        builder.get_object("box_position"),
+        "active",
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    settings.bind(
+        "logo-position",
+        builder.get_object("logo_position"),
+        "active",
+        Gio.SettingsBindFlags.DEFAULT
+    );
 
     // use connect_signals_full to attach signal handlers to buttons on gtk <4
     if (!_isGtk4) {
         let SignalHandler = {
-
             on_defaults_clicked(w) {
                 settings.reset("off");
                 settings.reset("paused");
-                settings.reset('display-format');
+                settings.reset("display-format");
             },
 
             on_resetNotRunning_clicked(w) {
@@ -160,8 +222,7 @@ function buildPrefsWidget() {
 
             on_resetLogo_clicked(w) {
                 settings.reset("logo-position");
-            },
-
+            }
         };
 
         builder.connect_signals_full((builder, object, signal, handler) => {
@@ -175,5 +236,7 @@ function buildPrefsWidget() {
 }
 
 function _checkIfGtk4() {
-    return Number.parseInt(imports.misc.config.PACKAGE_VERSION.split('.')) >= 40;
+    return (
+        Number.parseInt(imports.misc.config.PACKAGE_VERSION.split(".")) >= 40
+    );
 }


### PR DESCRIPTION
## Description
I saw that there was no consistent code formatting applied to the project, so I implemented that. I tried to stick to the existing code style as close as possible, but feel free to if you e.g. decide you want to have single quotes rather than double quotes everywhere.

Since gnome extensions don't have a `package.json` and `node_modules`, devs will need to have prettier installed as IDE extension to have formatting work.

## Changes
- add `.prettierrc.js` config file
- auto-format `.js`, `.json` and `.md` files