### PR TITLE
Gnome 43 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
         "3.38",
         "40",
         "41",
-        "42"
+        "42",
+        "43"
     ],
     "url": "https://github.com/esenliyim/sp-tray",
     "uuid": "sp-tray@sp-tray.esenliyim.github.com",


### PR DESCRIPTION
Gnome 43 tested and works correctly with the current release, added support to metadata.json