### PR TITLE
add support to GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
         "40",
         "41",
         "42",
-        "43"
+        "43",
+        "44"
     ],
     "url": "https://github.com/esenliyim/sp-tray",
     "uuid": "sp-tray@sp-tray.esenliyim.github.com",


### PR DESCRIPTION
Working fine on Gnome 44:

[Screencast from 2023-05-01 12-14-08.webm](https://user-images.githubusercontent.com/17055027/235475232-4710a128-239c-4877-9367-b4cd85358a68.webm)
