### PR TITLE
refactor: support gnome 45

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,4 @@
-var constants = {
+const constants = {
     logoPosition: {
         NONE: 0,
         LEFT: 1,

--- a/dbus.js
+++ b/dbus.js
@@ -1,4 +1,5 @@
-const { GLib, Gio } = imports.gi;
+import GLib from "gi://GLib";
+import Gio from "gi://Gio";
 
 //dbus constants
 const path = "/org/mpris/MediaPlayer2";
@@ -52,7 +53,7 @@ const supportedClients = [
     },
 ];
 
-var SpTrayDbus = class SpTrayDbus {
+const SpTrayDbus = class SpTrayDbus {
     constructor(panelButton) {
         this.proxy = null;
         this.panelButton = panelButton;
@@ -146,7 +147,7 @@ var SpTrayDbus = class SpTrayDbus {
             const unpacked = resp.deepUnpack();
             if (!this.shouldRetry(unpacked)) {
                 log(`Got good metadata on attempt ${attempt}`);
-                
+
                 try {
                     this.proxy.set_cached_property("Metadata", resp);
                 } catch (error) {

--- a/extension.js
+++ b/extension.js
@@ -15,14 +15,16 @@
 
 "use strict";
 
-const Main = imports.ui.main;
-const ExtUtil = imports.misc.extensionUtils;
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+
+import * as ExtUtil from "resource:///org/gnome/shell/misc/extensionUtils.js";
+
 const Me = ExtUtil.getCurrentExtension();
 
 const { SpTrayButton } = Me.imports.panelButton;
 const { constants } = Me.imports.constants;
 
-class SpTrayExtension {
+export default class SpTrayExtension {
     constructor() {
         this.extensionButton = null;
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,9 @@
 {
     "description": "Adds a button to the panel that shows information Spotify playback. For bug reports, feature requests, translation contributions, etc., please visit the extension's github page.",
     "name": "spotify-tray",
-    "shell-version": [
-        "40",
-        "41",
-        "42",
-        "43",
-        "44"
-    ],
+    "shell-version": ["45"],
     "url": "https://github.com/esenliyim/sp-tray",
     "uuid": "sp-tray@sp-tray.esenliyim.github.com",
-    "version": 21,
+    "version": 22,
     "settings-schema": "org.gnome.shell.extensions.sp-tray"
 }

--- a/panelButton.js
+++ b/panelButton.js
@@ -13,12 +13,16 @@
 //     You should have received a copy of the GNU General Public License
 // along with this program.If not, see < http://www.gnu.org/licenses/>.
 
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-const Main = imports.ui.main;
-const { St, Clutter, GObject, Gio, GLib } = imports.gi;
+import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+import St from "gi://St";
+import Clutter from "gi://Clutter";
+import GObject from "gi://GObject";
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
 
-const ExtensionUtils = imports.misc.extensionUtils;
+import * as ExtensionUtils from "resource:///org/gnome/shell/misc/extensionUtils.js";
+
 const Me = ExtensionUtils.getCurrentExtension();
 const { SpTrayDbus } = Me.imports.dbus;
 const { settingsFields } = Me.imports.settingsFields;
@@ -36,7 +40,7 @@ const marqueeTextGenerator = function* (label) {
     }
 };
 
-var SpTrayButton = GObject.registerClass(
+const SpTrayButton = GObject.registerClass(
     { GTypeName: "SpTrayButton" },
     class SpTrayButton extends PanelMenu.Button {
         _init() {
@@ -198,9 +202,7 @@ var SpTrayButton = GObject.registerClass(
         }
 
         _setMarqueeStyle(length) {
-            this.ui
-                .get("label")
-                .set_style(`width: ${length / 2}em;`);
+            this.ui.get("label").set_style(`width: ${length / 2}em;`);
         }
 
         destroy() {
@@ -331,7 +333,7 @@ var SpTrayButton = GObject.registerClass(
         _generateMarqueeText(metadata, shouldRestart) {
             this._pauseMarquee();
             const text = this._createFormattedText(metadata);
-            const marqueeLength = this.settings.get_int("marquee-length")
+            const marqueeLength = this.settings.get_int("marquee-length");
             if (text.length <= marqueeLength) {
                 this.ui.get("label").set_style(null); // let the system automatically decide the width
                 return text;

--- a/prefs.js
+++ b/prefs.js
@@ -13,10 +13,14 @@
 //     You should have received a copy of the GNU General Public License
 // along with this program.If not, see < http://www.gnu.org/licenses/>.
 
-const { GObject, Gtk, Gio } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
+import GObject from "gi://GObject";
+import Gtk from "gi://Gtk";
+import Gio from "gi://Gio";
+
+import * as ExtensionUtils from "resource:///org/gnome/shell/misc/extensionUtils.js";
+
 const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext;
+import * as Gettext from "resource:///org/gnome/shell/gettext.js";
 
 const { settingsFields } = Me.imports.settingsFields;
 

--- a/settingsFields.js
+++ b/settingsFields.js
@@ -1,4 +1,4 @@
-var settingsFields = [
+const settingsFields = [
     /*
     {
         setting: name in the settings schema,


### PR DESCRIPTION
## Changes

- convert imports across codebase to be compatible with gnome 45
- specify export default for SpTrayExtension class
- update shell-version in metadata.json to only support v45
- increment version from v21 to v22 in metadata.json
- change var keyword to const across the codebase

## Description

It would be great for potential contributors if there was a `CONTRIBUTING.md` file detailing the steps necessary to be able to contribute properly. I was blindly following along the guide at https://gjs.guide/extensions/upgrading/gnome-shell-45.html#esm but wasn't able to test anything out, etc

My intention was to at least kick this off an then hand it over to you @esenliyim :smiley: 

Closes https://github.com/esenliyim/sp-tray/issues/42